### PR TITLE
Upgrade text model to gpt-3.5-turbo (ChatGPT)

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -18,8 +18,8 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   const payload: OpenAIStreamPayload = {
-    model: "text-davinci-003",
-    prompt,
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
     top_p: 1,
     frequency_penalty: 0,

--- a/utils/OpenAIStream.ts
+++ b/utils/OpenAIStream.ts
@@ -4,9 +4,16 @@ import {
   ReconnectInterval,
 } from "eventsource-parser";
 
+export type ChatGPTAgent = "user" | "system";
+
+export interface ChatGPTMessage {
+  role: ChatGPTAgent;
+  content: string;
+}
+
 export interface OpenAIStreamPayload {
   model: string;
-  prompt: string;
+  messages: ChatGPTMessage[];
   temperature: number;
   top_p: number;
   frequency_penalty: number;
@@ -22,7 +29,7 @@ export async function OpenAIStream(payload: OpenAIStreamPayload) {
 
   let counter = 0;
 
-  const res = await fetch("https://api.openai.com/v1/completions", {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ""}`,
@@ -44,7 +51,7 @@ export async function OpenAIStream(payload: OpenAIStreamPayload) {
           }
           try {
             const json = JSON.parse(data);
-            const text = json.choices[0].text;
+            const text = json.choices[0].delta?.content || "";
             if (counter < 2 && (text.match(/\n/) || []).length) {
               // this is a prefix character (i.e., "\n\n"), do nothing
               return;


### PR DESCRIPTION
Generates text ~5x faster.

ChatGPT's underlying model, `gpt-3.5-turbo`, [became available in the API today](https://openai.com/blog/introducing-chatgpt-and-whisper-apis). It should cost 10x less per token. It's also much faster:

| | Before (`text-davinci-003`)  | After (`gpt-3.5-turbo`) |
| --- | ------------- | ------------- |
| Trial 1 | 3371.552 ms  | 622.586 ms  |
| Trial 2 | 2654.793 ms  | 688.590 ms  |
| Trial 3 | 2950.276 ms | 483.914 ms | 

I timed generations with the same prompt and tone using `console.time()` around the `reader.read()` loop in **index.tsx** [here](https://github.com/Nutlope/twitterbio/blob/main/pages/index.tsx#L60).

<img width="997" alt="image" src="https://user-images.githubusercontent.com/36117635/222270757-efd47bc9-e173-4b88-8fb9-2902b37c8141.png">

First PR in this repo; open to feedback on codestyle or PR etiquette!
