### PR TITLE
Use `TransformStream` and return SSE stream

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -30,7 +30,19 @@ const handler = async (req: Request): Promise<Response> => {
   };
 
   const stream = await OpenAIStream(payload);
-  return new Response(stream);
+  // return stream response (SSE)
+  return new Response(
+    stream, {
+      headers: new Headers({
+        // since we don't use browser's EventSource interface, specifying content-type is optional.
+        // the eventsource-parser library can handle the stream response as SSE, as long as the data format complies with SSE:
+        // https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#sending_events_from_the_server
+        
+        // 'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      })
+    }
+  );
 };
 
 export default handler;

--- a/utils/OpenAIStream.ts
+++ b/utils/OpenAIStream.ts
@@ -45,6 +45,19 @@ export async function OpenAIStream(payload: OpenAIStreamPayload) {
           controller.enqueue(encoder.encode(data));
         }
       }
+
+      // optimistic error handling
+      if (res.status !== 200) {
+        const data = {
+          status: res.status,
+          statusText: res.statusText,
+          body: await res.text(),
+        }
+        console.log(`Error: recieved non-200 status code, ${JSON.stringify(data)}`);
+        controller.close();
+        return
+      }
+        
       // stream response (SSE) from OpenAI may be fragmented into multiple chunks
       // this ensures we properly read chunks and invoke an event for each SSE event stream
       const parser = createParser(onParse);


### PR DESCRIPTION
Moving most parsing logic into `TransformStream`, which is a more appropriate interface for such stream chunk processing.

Some notes:
- we still need `ReadableStream` to properly handle fragmented SSE chunks from OpenAI
  - OpenAI -> (fragmented stream SSE chunks) -> `ReadableStream` -> ([`eventsource-parser`](https://github.com/rexxars/eventsource-parser) parses and restores each SSE event out of received fragmented SSE chunks) -> `TransformStream` (we parse each SSE event data (JSON) passed from `ReadableStream` and transform as needed) -> stream response (SSE) -> Client (browser)
- Clients are now also reading SSE stream emitted by edge functions using `eventsource-parser`. This makes client-side chunk data parsing logic much easier to work with.

internal link: https://vercel.slack.com/archives/C0289CGVAR2/p1680094016236659