### PR TITLE
Fix build: swap ts-expect-error for ts-ignore

### DIFF
--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
 
   const isReasoningModel = model === "Qwen/Qwen3.5-9B";
 
-  // @ts-expect-error chat_template_kwargs disables thinking for reasoning models
+  // @ts-ignore chat_template_kwargs disables thinking for reasoning models
   const runner = together.chat.completions.stream({
     model,
     messages: [{ role: "user", content: prompt }],


### PR DESCRIPTION
## Summary
- `@ts-expect-error` fails the build because the Together SDK accepts `chat_template_kwargs` without a type error, making the directive unused
- Swap to `@ts-ignore` to suppress without requiring an actual error

## Test plan
- [ ] `next build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)