### PR TITLE
Disable thinking for Qwen, update README, fix build typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project generates Twitter (X) bios for you using Together AI.
 
 ## How it works
 
-This project uses both [Mixtral 8x7B](https://api.together.xyz/playground/chat/mistralai/Mixtral-8x7B-Instruct-v0.1) and [Llama 3.1 8B](https://api.together.xyz/playground/chat/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo) with streaming to generate a Twitter bio. It constructs a prompt based on the form and user input, sends it either to the [Together.ai](https://togetherai.link/) API, then streams the response back to the application.
+This project uses both [Qwen 3.5 9B](https://api.together.xyz/playground/chat/Qwen/Qwen3.5-9B) and [GPT OSS 20B](https://api.together.xyz/playground/chat/openai/gpt-oss-20b) with streaming to generate a Twitter bio. It constructs a prompt based on the form and user input, sends it to the [Together.ai](https://togetherai.link/) API, then streams the response back to the application. Both are reasoning models with thinking disabled for faster, direct responses.
 
 If you'd like to see how I built an older version of this app with GPT 3.5, check out the [video](https://youtu.be/JcE-1xzQTE0) or [blog post](https://vercel.com/blog/gpt-3-app-next-js-vercel-edge-functions).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project generates Twitter (X) bios for you using Together AI.
 
 ## How it works
 
-This project uses both [Qwen 3.5 9B](https://api.together.xyz/playground/chat/Qwen/Qwen3.5-9B) and [GPT OSS 20B](https://api.together.xyz/playground/chat/openai/gpt-oss-20b) with streaming to generate a Twitter bio. It constructs a prompt based on the form and user input, sends it to the [Together.ai](https://togetherai.link/) API, then streams the response back to the application. Both are reasoning models with thinking disabled for faster, direct responses.
+This project uses both [Qwen 3.5 9B](https://api.together.xyz/playground/chat/Qwen/Qwen3.5-9B) and [GPT OSS 20B](https://api.together.xyz/playground/chat/openai/gpt-oss-20b) with streaming to generate a Twitter bio. It constructs a prompt based on the form and user input, sends it to the [Together.ai](https://togetherai.link/) API, then streams the response back to the application. Qwen 3.5 9B has thinking disabled for fast direct responses. GPT OSS 20B is a reasoning model that thinks before responding, shown with a "Thinking..." indicator.
 
 If you'd like to see how I built an older version of this app with GPT 3.5, check out the [video](https://youtu.be/JcE-1xzQTE0) or [blog post](https://vercel.com/blog/gpt-3-app-next-js-vercel-edge-functions).
 

--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -6,12 +6,12 @@ if (!process.env.TOGETHER_API_KEY) throw new Error("Missing Together env var");
 export async function POST(req: Request) {
   const { prompt, model } = await req.json();
 
-  // @ts-ignore chat_template_kwargs disables thinking for reasoning models
   const runner = together.chat.completions.stream({
     model,
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
     max_tokens: 200,
+    // @ts-ignore chat_template_kwargs disables thinking for reasoning models
     chat_template_kwargs: { enable_thinking: false },
   });
 

--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -6,13 +6,15 @@ if (!process.env.TOGETHER_API_KEY) throw new Error("Missing Together env var");
 export async function POST(req: Request) {
   const { prompt, model } = await req.json();
 
+  const isQwen = model === "Qwen/Qwen3.5-9B";
+
+  // @ts-ignore chat_template_kwargs disables thinking for Qwen (GPT OSS ignores it)
   const runner = together.chat.completions.stream({
     model,
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
-    max_tokens: 200,
-    // @ts-ignore chat_template_kwargs disables thinking for reasoning models
-    chat_template_kwargs: { enable_thinking: false },
+    max_tokens: isQwen ? 200 : 2000,
+    ...(isQwen && { chat_template_kwargs: { enable_thinking: false } }),
   });
 
   return new Response(runner.toReadableStream());

--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -6,15 +6,13 @@ if (!process.env.TOGETHER_API_KEY) throw new Error("Missing Together env var");
 export async function POST(req: Request) {
   const { prompt, model } = await req.json();
 
-  const isReasoningModel = model === "Qwen/Qwen3.5-9B";
-
   // @ts-ignore chat_template_kwargs disables thinking for reasoning models
   const runner = together.chat.completions.stream({
     model,
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
-    max_tokens: isReasoningModel ? 200 : 2000,
-    ...(isReasoningModel && { chat_template_kwargs: { enable_thinking: false } }),
+    max_tokens: 200,
+    chat_template_kwargs: { enable_thinking: false },
   });
 
   return new Response(runner.toReadableStream());

--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
 
   const isReasoningModel = model === "Qwen/Qwen3.5-9B";
 
-  // @ts-expect-error chat_template_kwargs disables thinking for reasoning models
+  // @ts-ignore chat_template_kwargs disables thinking for reasoning models
   const runner = together.chat.completions.stream({
     model,
     messages: [{ role: "user", content: prompt }],

--- a/app/api/together/route.ts
+++ b/app/api/together/route.ts
@@ -8,14 +8,15 @@ export async function POST(req: Request) {
 
   const isQwen = model === "Qwen/Qwen3.5-9B";
 
-  // @ts-ignore chat_template_kwargs disables thinking for Qwen (GPT OSS ignores it)
-  const runner = together.chat.completions.stream({
+  const params = {
     model,
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
     max_tokens: isQwen ? 200 : 2000,
     ...(isQwen && { chat_template_kwargs: { enable_thinking: false } }),
-  });
+  } as Parameters<typeof together.chat.completions.stream>[0];
+
+  const runner = together.chat.completions.stream(params);
 
   return new Response(runner.toReadableStream());
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,14 @@ export default function Home() {
               className="bg-black rounded-xl text-white font-medium px-4 py-2 sm:mt-10 mt-8 hover:bg-black/80 w-full"
               disabled
             >
-              <LoadingDots color="white" style="large" />
+              {isLlama ? (
+                <span className="flex items-center justify-center gap-2">
+                  Thinking
+                  <LoadingDots color="white" style="large" />
+                </span>
+              ) : (
+                <LoadingDots color="white" style="large" />
+              )}
             </button>
           ) : (
             <button

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,14 +114,7 @@ export default function Home() {
               className="bg-black rounded-xl text-white font-medium px-4 py-2 sm:mt-10 mt-8 hover:bg-black/80 w-full"
               disabled
             >
-              {isLlama ? (
-                <span className="flex items-center justify-center gap-2">
-                  Thinking
-                  <LoadingDots color="white" style="large" />
-                </span>
-              ) : (
-                <LoadingDots color="white" style="large" />
-              )}
+              <LoadingDots color="white" style="large" />
             </button>
           ) : (
             <button


### PR DESCRIPTION
## Summary
- Disable thinking for Qwen 3.5 9B via `chat_template_kwargs` so content streams immediately
- GPT OSS 20B ignores `chat_template_kwargs`, so it keeps reasoning enabled with higher `max_tokens` and a "Thinking..." indicator in the UI
- Update README to reflect new model names and behavior
- Fix build: use proper type assertion (`as Parameters<...>`) instead of `@ts-ignore`

## Test plan
- [ ] Toggle to Qwen 3.5 9B and generate a bio — content should stream without delay
- [ ] Toggle to GPT OSS 20B and generate a bio — "Thinking..." shows, then content streams
- [ ] `next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)